### PR TITLE
Fix compilation failure with a fresh Rust 2021 project

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor_parallel.rs
+++ b/crates/bevy_ecs/src/schedule/executor_parallel.rs
@@ -132,7 +132,7 @@ impl ParallelSystemExecutor for ParallelExecutor {
                             .finish_receiver
                             .recv()
                             .await
-                            .unwrap_or_else(|error| unreachable!(error));
+                            .unwrap_or_else(|error| unreachable!("{}", error));
                         self.process_finished_system(index);
                         // Gather other systems than may have finished.
                         while let Ok(index) = self.finish_receiver.try_recv() {
@@ -208,7 +208,7 @@ impl ParallelExecutor {
                     start_receiver
                         .recv()
                         .await
-                        .unwrap_or_else(|error| unreachable!(error));
+                        .unwrap_or_else(|error| unreachable!("{}", error));
                     #[cfg(feature = "trace")]
                     let system_guard = system_span.enter();
                     unsafe { system.run_unsafe((), world) };
@@ -217,7 +217,7 @@ impl ParallelExecutor {
                     finish_sender
                         .send(index)
                         .await
-                        .unwrap_or_else(|error| unreachable!(error));
+                        .unwrap_or_else(|error| unreachable!("{}", error));
                 };
 
                 #[cfg(feature = "trace")]
@@ -268,7 +268,7 @@ impl ParallelExecutor {
                     .start_sender
                     .send(())
                     .await
-                    .unwrap_or_else(|error| unreachable!(error));
+                    .unwrap_or_else(|error| unreachable!("{}", error));
                 self.running.set(index, true);
                 if !system_metadata.is_send {
                     self.non_send_running = true;

--- a/crates/bevy_openxr/src/interaction/tracking.rs
+++ b/crates/bevy_openxr/src/interaction/tracking.rs
@@ -45,8 +45,8 @@ pub fn predict_pose(
         return None;
     }
 
-    let linear_velocity = velocity.linear_velocity.map(to_vec3);
-    let angular_velocity = velocity.angular_velocity.map(to_vec3);
+    let linear_velocity = Some(to_vec3(velocity.linear_velocity));
+    let angular_velocity = Some(to_vec3(velocity.angular_velocity));
 
     Some(XrPose {
         transform: openxr_pose_to_corrected_rigid_transform(


### PR DESCRIPTION
# Objective

I was interested in trying this out, but noticed that it wouldn't build with a fresh Rust 2021 project with the latest dependencies. I tracked this down to Rust 2021 changing how `unreachable` works (which Bevy upstream has already fixed), as well as a change to `openxrs`.

## Solution

I've cherry-picked the relevant Bevy commit and `Option`-wrapped the velocities from `openxrs` (as they are no longer `Option`s). Quick notes on this:
1) I was initially intending to bring this fork up to Bevy HEAD, but they have (un)fortunately made some semi-significant changes to how PBR light clustering works, among other changes to the rendering pipeline, and I don't have enough context to do that merge myself without spending too much time on it. I decided to compromise by bringing across the one commit I needed 😆 
2) I considered removing the `Option`s from `XrPose` directly, but it seems like they're used elsewhere in the code and I didn't want to make any sweeping changes. Will leave it up to you to decide whether or not this needs more work later.

While I'm here: very cool work from you/zarik5/everyone else involved. I'm looking forward to a Bevy+XR future!
